### PR TITLE
Unify mui and msp install

### DIFF
--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@ $ErrorActionPreference = 'Stop'
 
 $DisplayName = 'Adobe Acrobat Reader DC MUI'
 
-$MUIurl            = 'http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1901020064/AcroRdrDC1901020064_MUI.exe'
-$MUIchecksum       = '81953f3cf426cbe9e6702d1af7f727c59514c012d8d90bacfb012079c7da6d23'
+$MUIurl            = 'https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
+$MUIchecksum       = 'dfc4b3c70b7ecaeb40414c9d6591d8952131a5fffa0c0f5964324af7154f8111'
 $MUImspURL = 'http://ftp.adobe.com/pub/adobe/reader/win/AcrobatDC/1902120056/AcroRdrDCUpd1902120056_MUI.msp'
 $MUImspChecksum = '149c70260a30d7b1fe4d02504ff346b9abdf51f4d79c3ab082f82d35f468adca478f175d8582fa40380dced162df92e069af736ce0f5d015c93cd0815b0e98fc'
 

--- a/package/update.ps1
+++ b/package/update.ps1
@@ -21,24 +21,9 @@ function global:au_GetLatest {
                   Where-Object {$_ -match '\d\.msp$'} |
                   Select-Object -First 1
 
-   # Find the most-recent EXE
-   $FTPpage = Invoke-WebRequest -Uri $FTPbase -UseBasicParsing -DisableKeepAlive
-   $Folders = $FTPpage.rawcontent -split '[\r\n]' | 
-                  Where-Object {$_ -match '>\d+<'} |
-                  ForEach-Object {$_ -replace '.*>(\d+)<.*','$1'} |
-                  Sort-Object -Descending
-   foreach ($folder in $Folders) {
-      $FolderFiles = Invoke-WebRequest -Uri "$FTPbase/$folder" -UseBasicParsing -DisableKeepAlive
-      $EXEstub = $FolderFiles.rawcontent -split '"' |
-                     Where-Object {$_ -match 'en_US\.exe$'} |
-                     Select-Object -First 1
-      if ($EXEstub) { break }
-   }
-   $MUIstub = $EXEstub -replace 'en_US','MUI'
-
    return  @{ 
        Version   = $version
-       URL32     = "http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/$MUIstub"
+       URL32     = "https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe"
        MUIMSPurl = "$FTPbase/$MUIMSPstub"
    }
 }


### PR DESCRIPTION
I believe that using Acrobat Reader DC base installer is more reasonable and easier to maintain since all update is based on it, besides approximately half size of latest installer.
Furthermore, putting mui and msp installer together, I suggest, bring consistent experience compared to install them alone.
