### PR TITLE
Allow desktop icon

### DIFF
--- a/adobereader/tools/chocolateyInstall.ps1
+++ b/adobereader/tools/chocolateyInstall.ps1
@@ -61,7 +61,7 @@ $PackageParameters   = Get-PackageParameters
 # Reference: https://www.adobe.com/devnet-docs/acrobatetk/tools/AdminGuide/properties.html#command-line-example
 $options = ' DISABLEDESKTOPSHORTCUT=1'
 if ($PackageParameters.DesktopIcon) {
-   $options += ''
+   $options = ''
    Write-Host 'You requested a desktop icon.' -ForegroundColor Cyan
 }
 


### PR DESCRIPTION
An extra character was preventing the desktop icon even if the user requested it.